### PR TITLE
Fix atom handling

### DIFF
--- a/__tests__/http/analyzers/atom.js
+++ b/__tests__/http/analyzers/atom.js
@@ -87,6 +87,33 @@ describe('http.analyzers.atom', () => {
     ])
   })
 
+  it('should support various content types', async () => {
+    const url = await serveFile(path.resolve(__dirname, '../../__fixtures__/atom-empty.xml'))
+
+    const contentTypes = [
+      'text/xml',
+      'application/xml'
+    ]
+
+    await Promise.all(
+      contentTypes.map(async ct => {
+        const token = {
+          url,
+          fileTypes: [
+            {mime: ct}
+          ]
+        }
+
+        await fetch(token, options)
+        await analyzeAtom(token, options)
+
+        expect(token.analyzed).toBeTruthy()
+        expect(token.type).toBe('atom')
+        expect(token.children).toHaveLength(0)
+      })
+    )
+  })
+
   it('should not extract any child for an empty atom feed', async () => {
     const url = await serveFile(path.resolve(__dirname, '../../__fixtures__/atom-empty.xml'))
 
@@ -102,10 +129,10 @@ describe('http.analyzers.atom', () => {
 
     expect(token.analyzed).toBeTruthy()
     expect(token.type).toBe('atom')
-    expect(token.children).toBeUndefined()
+    expect(token.children).toHaveLength(0)
   })
 
-  it('should fail for non atom feeds', async () => {
+  it('should not analyze non atom feeds', async () => {
     const url = await serveFile(path.resolve(__dirname, '../../__fixtures__/file.txt'))
 
     const token = {
@@ -116,7 +143,8 @@ describe('http.analyzers.atom', () => {
     }
 
     await fetch(token, options)
+    await analyzeAtom(token, options)
 
-    return expect(analyzeAtom(token, options)).rejects.toThrow('Not a feed')
+    return expect(token.analyzed).toBeFalsy()
   })
 })

--- a/lib/http/analyzers/atom.js
+++ b/lib/http/analyzers/atom.js
@@ -10,12 +10,15 @@ function extractItems(token) {
   return new Promise((resolve, reject) => {
     const items = []
 
-    const parser = pipe(token.response, new FeedParser(), err => {
-      if (err) {
-        return reject(err)
+    const parser = pipe(token.response, new FeedParser(), error => {
+      if (error) {
+        if (error.message === 'Not a feed') {
+          return resolve({isAtom: false})
+        }
+        return reject(error)
       }
 
-      resolve(items)
+      resolve({isAtom: true, items})
     })
 
     parser.on('readable', function () {
@@ -33,29 +36,39 @@ async function analyzeAtom(token, options) {
     return false
   }
 
-  const isAtom = token.fileTypes.some(type => is(type.mime, 'application/atom+xml'))
-  if (!isAtom) {
+  const canBeAtom = token.fileTypes.some(type => is(
+    type.mime,
+    'application/atom+xml',
+    'text/xml',
+    'application/xml'
+  ))
+
+  if (!canBeAtom) {
     return false
   }
 
   options.logger.log('atom:analyze:start', token)
-  const items = await bufferize(token, () => extractItems(token))
+  const {isAtom, items} = await bufferize(token, () => extractItems(token))
   options.logger.log('atom:analyze:end', token)
 
-  if (items.length > 0) {
-    token.children = items.map(item => ({
-      inputType: 'url',
-      url: item.link,
-      meta: {
-        title: item.title,
-        description: item.description,
-        summary: item.summary,
-        author: item.author
-      }
-    }))
+  if (isAtom) {
+    token.type = 'atom'
+    token.analyzed = true
+    token.children = []
+
+    if (items.length > 0) {
+      token.children = items.map(item => ({
+        inputType: 'url',
+        url: item.link,
+        meta: {
+          title: item.title,
+          description: item.description,
+          summary: item.summary,
+          author: item.author
+        }
+      }))
+    }
   }
-  token.type = 'atom'
-  token.analyzed = true
 }
 
 module.exports = analyzeAtom


### PR DESCRIPTION
Support text/xml and application/xml content types.
Go on to the next analyzer if the input is not an atom feed.
Return an empty array of children for empty feeds.